### PR TITLE
Revert to use of Scanner in Panel.java

### DIFF
--- a/src/codeu/chat/client/commandline/Panel.java
+++ b/src/codeu/chat/client/commandline/Panel.java
@@ -27,7 +27,7 @@ import java.util.Scanner;
 final class Panel {
 
   public interface Command {
-    void invoke(List<String> args);
+    void invoke(Scanner line);
   }
 
   private final Map<String, Command> commands = new HashMap<>();


### PR DESCRIPTION
The use of  List in Panel.java was breaking the build since not all Tokenizer features were implemented. This pull request will reverse that change.