### PR TITLE
Quick fix for a-change

### DIFF
--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -693,6 +693,9 @@ public final class Chat {
         case ERROR_NOT_ALLOWED:
           System.out.println("ERROR: You do not have sufficient permission to change this user's permission level.");
           break;
+        case ERROR_OWN_PERMISSIONS:
+          System.out.println("ERROR: You are not allowed to modify your own permission level.");
+          break;
         default:
           System.out.println("ERROR: No proper response returned.");
           break;

--- a/src/codeu/chat/client/core/ConversationContext.java
+++ b/src/codeu/chat/client/core/ConversationContext.java
@@ -90,7 +90,7 @@ public final class ConversationContext {
   }
 
   public enum response {
-    NO_ERROR, ERROR_ALREADY_CURRENT_SETTING, ERROR_NOT_FOUND, ERROR_NOT_ALLOWED
+    NO_ERROR, ERROR_ALREADY_CURRENT_SETTING, ERROR_NOT_FOUND, ERROR_NOT_ALLOWED, ERROR_OWN_PERMISSIONS
   }
 
   public response addUserToConversation(String name) {
@@ -120,6 +120,8 @@ public final class ConversationContext {
         return response.ERROR_ALREADY_CURRENT_SETTING;
       case -2:
         return response.ERROR_NOT_ALLOWED;
+      case -3:
+        return response.ERROR_OWN_PERMISSIONS;
       default:
         return response.ERROR_NOT_FOUND;
     }

--- a/src/codeu/chat/server/Controller.java
+++ b/src/codeu/chat/server/Controller.java
@@ -286,38 +286,53 @@ public final class Controller implements RawController, BasicController {
             LOG.info("Permission level of user " + name + " changed to " + permissionLevel +".");
             return 0;
           case -1:
-            LOG.info("ERROR: User is not part of he conversation.");
+            LOG.info("ERROR: Specified user already at permission level.");
             return -1;
           case -2:
             LOG.info("ERROR: User attempting command does not have permission to change.");
             return -2;
+          case -3:
+            LOG.info("ERROR: User not allowed to change own permissions.");
+            return -3;
           default:
             break;
           }
         } else {
           LOG.info("ERROR: User or conversation not found.");
-          return -3;
+          return -4;
         }
 
-        return -3;
+        return -4;
       }
 
     private int verifyPermissionLevelChange(User foundUser, ConversationHeader foundConversation, int permissionLevel, Uuid currentUser) {
       final int currentPermissionLevel = foundConversation.userCategory.get(currentUser);
 
-      if (foundConversation.userCategory.containsKey(foundUser)) {
+      if(foundUser.id.equals(currentUser)) {
+        return -3;
+      }
+
+      if (foundConversation.userCategory.containsKey(foundUser.id)) {
         switch (currentPermissionLevel) {
           case 1:
             return -2;
           case 2:
             if (permissionLevel < currentPermissionLevel) {
-              return 0;
+              if (foundConversation.userCategory.get(foundUser.id) == permissionLevel) {
+                return -1;
+              } else {
+                return 0;
+              }
             } else {
               return -2;
             }
           case 3:
             if (permissionLevel < currentPermissionLevel) {
-              return 0;
+              if (foundConversation.userCategory.get(foundUser.id) == permissionLevel) {
+                return -1;
+              } else {
+                return 0;
+              }
             } else {
               return -2;
             }
@@ -326,7 +341,7 @@ public final class Controller implements RawController, BasicController {
           }
         }
 
-        return -3;
+        return -4;
       }
 
   private Uuid createId() {


### PR DESCRIPTION
Quick fix for logic issues in a-change command. User can no longer modify their own permissions. User is now notified if they try to change a user's permission level to the level that it is already at.